### PR TITLE
Added http_args option to allow passing arbitrary args to HTTParty.  …

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ woocommerce = WooCommerce::API.new(
 | `signature_method`  | `String` | no       | Signature method used for oAuth requests, works with `HMAC-SHA1` and `HMAC-SHA256`, default is `HMAC-SHA256` |
 | `query_string_auth` | `Bool`   | no       | Force Basic Authentication as query string when `true` and using under HTTPS, default is `false`             |
 | `debug_mode`        | `Bool`   | no       | Enables HTTParty debug mode                                                                                  |
+| `http_args`         | `Hash`   | no       | Allows extra arbitrary args to be passed to HTTParty, for example, `timeout:` if the default 10 seconds isn't long enough to allow multiple image uploads            |
 
 ## Methods
 

--- a/lib/woocommerce_api.rb
+++ b/lib/woocommerce_api.rb
@@ -18,7 +18,8 @@ module WooCommerce
         wp_api: false,
         version: "v3",
         verify_ssl: true,
-        signature_method: "HMAC-SHA256"
+        signature_method: "HMAC-SHA256",
+        http_args: {}
       }
       args = defaults.merge(args)
 
@@ -28,6 +29,7 @@ module WooCommerce
       @signature_method = args[:signature_method]
       @debug_mode = args[:debug_mode]
       @query_string_auth = args[:query_string_auth]
+      @http_args = args[:http_args]
 
       # Internal args
       @is_ssl = @url.start_with? "https"
@@ -122,6 +124,7 @@ module WooCommerce
     # Returns the response in JSON String.
     def do_request method, endpoint, data = {}
       url = get_url(endpoint, method)
+      
       options = {
         format: :json,
         verify: @verify_ssl,
@@ -131,6 +134,9 @@ module WooCommerce
           "Accept" => "application/json"
         }
       }
+
+      # Fold in any options supplied to the constructor, (eg. timeout)
+      options = @http_args.merge(options)
 
       # Set basic authentication.
       if @is_ssl


### PR DESCRIPTION
This is particularly useful to override the default timeout.  I find I need to when updating a Product with a large number of gallery images (especially when using S3 for image storage), as the single Product update involves uploading all the images in one batch. This can easily take more than the default 10 seconds, so without this option, will timeout even when working successfully.

Here's a snippet of me using this option:

```
    @woocommerce = WooCommerce::API.new(
      "http://" + wooconfig['url'],
      wooconfig["consumer_key"], # Your consumer key
      wooconfig["consumer_secret"], # Your consumer secret
      {
        wp_api: true, # Enable the WP REST API integration
        version: "wc/v1",
        debug_mode: false,
        http_args: { timeout: 60 }
      }
    )
```
