### PR TITLE
Do not include Content-Type header for GET request

### DIFF
--- a/lib/woocommerce_api.rb
+++ b/lib/woocommerce_api.rb
@@ -122,14 +122,15 @@ module WooCommerce
     # Returns the response in JSON String.
     def do_request method, endpoint, data = {}
       url = get_url(endpoint, method)
+      headers = {
+        "User-Agent" => "WooCommerce API Client-Ruby/#{WooCommerce::VERSION}",
+        "Accept" => "application/json"
+      }
+      headers["Content-Type"] = "application/json;charset=utf-8" if !data.empty?
       options = {
         format: :json,
         verify: @verify_ssl,
-        headers: {
-          "User-Agent" => "WooCommerce API Client-Ruby/#{WooCommerce::VERSION}",
-          "Content-Type" => "application/json;charset=utf-8",
-          "Accept" => "application/json"
-        }
+        headers: headers
       }
 
       # Set basic authentication.


### PR DESCRIPTION
This fixes an issue with WordPress 4.7. A `rest_invalid_json` would be returned if `Content-Type` is `application/json` but there's no body.