### PR TITLE
Allow To Overwrite httparty default format options

### DIFF
--- a/lib/woocommerce_api.rb
+++ b/lib/woocommerce_api.rb
@@ -129,7 +129,7 @@ module WooCommerce
       }
 
       # Allow custom HTTParty args.
-      options = @httparty_args.merge(options)
+      options = options.merge(@httparty_args)
 
       # Set headers.
       options[:headers] = {


### PR DESCRIPTION
I faced a unique issue, that certain woocommerce plugins cause the HTTParty response to have a BOM character which is very troublesome and `JSON.parse` will cause an `Unexpected Token Error`
The solution I came across was to pass additional parameters in `JSON.parse` for the HTTParty Response in plain format

`JSON.parse(response.encode('utf-8', 'binary', :undef => :replace, :replace => ''))`

The change allows us to change the default HTTParty `format:` argument to `plain:`, if required.